### PR TITLE
Improve training config and docs

### DIFF
--- a/final_rap_ai/README.md
+++ b/final_rap_ai/README.md
@@ -1,1 +1,36 @@
-See Colab instructions in chat.
+# Final Rap AI
+
+Command line tool for scraping lyrics, preprocessing text, training a language model with LoRA, and generating rap verses.
+
+## Installation
+
+Install the required Python packages. Internet access is required to download them from PyPI:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+The `cli.py` script exposes four commands:
+
+* `scrape` - Download song lyrics from the Genius API.
+* `prep` - Clean up the raw lyrics and collapse repeated lines.
+* `train` - Fine-tune the base model using LoRA adapters.
+* `gen` - Generate new lyrics from a trained model.
+
+Example workflow:
+
+```bash
+# 1. Scrape lyrics (requires GENIUS_TOKEN env var)
+python cli.py scrape --artists "Artist Name" --out data/raw.txt
+
+# 2. Preprocess the text
+python cli.py prep --in data/raw.txt --out data/clean.txt
+
+# 3. Train an adapter
+python cli.py train --corpus data/clean.txt --out models/rap-lora
+
+# 4. Generate text
+python cli.py gen --model-dir models/rap-lora --prompt "<INTRO>\n"
+```

--- a/final_rap_ai/final_rap_ai/dataset.py
+++ b/final_rap_ai/final_rap_ai/dataset.py
@@ -1,8 +1,15 @@
 from datasets import load_dataset
+from pathlib import Path
 def build(path, tokenizer, block=128, num_proc=4):
+    path = Path(path)
     ds = load_dataset("text", data_files=str(path))
-    tok = ds.map(lambda b: tokenizer(b["text"]), batched=True, num_proc=num_proc, remove_columns=["text"])
-    tok = tok.remove_columns([c for c in tok["train"].column_names if c!="input_ids"])
+    tok = ds.map(
+        lambda b: tokenizer(b["text"]),
+        batched=True,
+        num_proc=num_proc,
+        remove_columns=["text"],
+    )
+    tok = tok.remove_columns([c for c in tok["train"].column_names if c != "input_ids"])
     def group(b):
         concat = sum(b["input_ids"], [])
         n = len(concat)//block*block

--- a/final_rap_ai/final_rap_ai/trainer.py
+++ b/final_rap_ai/final_rap_ai/trainer.py
@@ -3,14 +3,19 @@ import logging
 from pathlib import Path
 from transformers import AutoTokenizer, AutoModelForCausalLM, TrainingArguments, Trainer, DataCollatorForLanguageModeling
 from peft import LoraConfig, get_peft_model, prepare_model_for_kbit_training
+import torch
 from .dataset import build
 LOG = logging.getLogger(__name__)
 DEFAULT = "mistralai/Mistral-7B-Instruct-v0.2"
 
 def train(corpus="data/clean.txt", out="models/rap-lora", base=DEFAULT, epochs=3, batch=1, lr=2e-4):
     from bitsandbytes import BitsAndBytesConfig
-    qc = BitsAndBytesConfig(load_in_4bit=True, bnb_4bit_use_double_quant=True,
-                            bnb_4bit_quant_type="nf4", bnb_4bit_compute_dtype="float16")
+    qc = BitsAndBytesConfig(
+        load_in_4bit=True,
+        bnb_4bit_use_double_quant=True,
+        bnb_4bit_quant_type="nf4",
+        bnb_4bit_compute_dtype=torch.float16,
+    )
     tok = AutoTokenizer.from_pretrained(base, use_fast=True)
     tok.pad_token = tok.eos_token
     model = AutoModelForCausalLM.from_pretrained(base, quantization_config=qc)


### PR DESCRIPTION
## Summary
- update README with setup and usage instructions
- fix `bnb_4bit_compute_dtype` in the training script
- handle string path for dataset builder and import `torch`

## Testing
- `python -m py_compile final_rap_ai/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68706b23038c83238180ca247b1f9c93