### PR TITLE
Pin peft version

### DIFF
--- a/final_rap_ai/requirements.txt
+++ b/final_rap_ai/requirements.txt
@@ -2,7 +2,7 @@ numpy<2.0
 torch==2.1.2
 transformers==4.40.2
 datasets==2.19.0
-peft==0.11.2
+peft==0.11.1
 accelerate==0.30.1
 bitsandbytes==0.42.0 ; platform_system!="Darwin"
 lyricsgenius==3.0.1


### PR DESCRIPTION
## Summary
- pin the peft version to 0.11.1
- verify requirements installation with `pip`

## Testing
- `pip install --no-deps -U peft==0.11.1`
- `pip install --dry-run --no-deps -r final_rap_ai/requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_687072d414508323bddad09d86fb79e3